### PR TITLE
Add braking to half the drivetrain

### DIFF
--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -58,10 +58,14 @@ class Drivetrain(Subsystem):
         self.locked = False
         self.vision_stable = False
 
+        # Half the motors need to be inverted to run the right direction and
+        # half are in brake mode to slow the robot down faster but also not
+        # make it come to a complete stop too quickly.
         self.frontLeft = swervemodule.SwerveModule(
             RMM.front_left_drive,
             RMM.front_left_turn,
             RMM.front_left_turn_encoder,
+            True,
             True,
             'Front left')
         self.frontRight = swervemodule.SwerveModule(
@@ -69,17 +73,20 @@ class Drivetrain(Subsystem):
             RMM.front_right_turn,
             RMM.front_right_turn_encoder,
             False,
+            False,
             'Front right')
         self.backLeft = swervemodule.SwerveModule(
             RMM.back_left_drive,
             RMM.back_left_turn,
             RMM.back_left_turn_encoder,
             True,
+            True,
             'Back left')
         self.backRight = swervemodule.SwerveModule(
             RMM.back_right_drive,
             RMM.back_right_turn,
             RMM.back_right_turn_encoder,
+            False,
             False,
             'Back right')
 

--- a/subsystems/swervemodule.py
+++ b/subsystems/swervemodule.py
@@ -25,6 +25,10 @@ kWheelRadius = 0.0508  # m
 # encoder_to_mech_ratio = 2.50
 encoder_to_mech_ratio = 6.11
 
+BRAKE = signals.NeutralModeValue.BRAKE
+COAST = signals.NeutralModeValue.COAST
+CCW = signals.InvertedValue.COUNTER_CLOCKWISE_POSITIVE
+CW = signals.InvertedValue.CLOCKWISE_POSITIVE
 
 class SwerveModule(Subsystem):
     def __init__(
@@ -33,6 +37,7 @@ class SwerveModule(Subsystem):
         turningMotorChannel: int,
         canCoderChannel: int,
         inverted: bool,
+        brake: bool,
         name: str,
     ) -> None:
         self.name = name
@@ -49,10 +54,8 @@ class SwerveModule(Subsystem):
         driveConfigurator = self.driveMotor.configurator
 
         drive_Output = configs.MotorOutputConfigs()
-        if inverted:
-            drive_Output.inverted = signals.InvertedValue.COUNTER_CLOCKWISE_POSITIVE
-        else:
-            drive_Output.inverted = signals.InvertedValue.CLOCKWISE_POSITIVE
+        drive_Output.neutral_mode = BRAKE if brake else COAST
+        drive_Output.inverted = CCW if inverted else CW
         driveConfigurator.apply(drive_Output)
         drive_feedback = configs.FeedbackConfigs()
         drive_feedback.with_sensor_to_mechanism_ratio(encoder_to_mech_ratio)


### PR DESCRIPTION
Places two motors that are diagonal to each other on the drive train into braking mode to help the robot slow down faster when the driver lets up on the joysticks. Saw the suggestion on Chief Delphi to only do it to half the motors.