### PR TITLE
Add robot pose visual to system

### DIFF
--- a/simgui-window.json
+++ b/simgui-window.json
@@ -8,31 +8,48 @@
       "height": "900",
       "maximized": "0",
       "style": "0",
-      "userScale": "2",
+      "userScale": "4",
       "width": "1600",
-      "xpos": "-1",
-      "ypos": "-1"
+      "xpos": "160",
+      "ypos": "106"
+    }
+  },
+  "Table": {
+    "0x542B5671,2": {
+      "Column 0  Width": "260",
+      "Column 1  Width": "228",
+      "RefScale": "19"
     }
   },
   "Window": {
+    "###/SmartDashboard/Field": {
+      "Collapsed": "0",
+      "Pos": "729,-22",
+      "Size": "937,664"
+    },
+    "###Addressable LEDs": {
+      "Collapsed": "0",
+      "Pos": "13,432",
+      "Size": "199,436"
+    },
     "###FMS": {
       "Collapsed": "0",
-      "Pos": "6,675",
-      "Size": "336,158"
+      "Pos": "240,675",
+      "Size": "388,176"
     },
     "###Joysticks": {
       "Collapsed": "0",
       "Pos": "312,581",
-      "Size": "976,82"
+      "Size": "1156,91"
     },
     "###NetworkTables": {
       "Collapsed": "0",
-      "Pos": "312,346",
-      "Size": "937,231"
+      "Pos": "99,40",
+      "Size": "635,613"
     },
     "###NetworkTables Info": {
       "Collapsed": "0",
-      "Pos": "312,162",
+      "Pos": "326,714",
       "Size": "937,181"
     },
     "###Other Devices": {
@@ -42,13 +59,13 @@
     },
     "###System Joysticks": {
       "Collapsed": "0",
-      "Pos": "6,437",
-      "Size": "232,254"
+      "Pos": "15,185",
+      "Size": "273,290"
     },
     "###Timing": {
       "Collapsed": "0",
       "Pos": "6,187",
-      "Size": "162,168"
+      "Size": "188,186"
     },
     "Debug##Default": {
       "Collapsed": "0",
@@ -58,7 +75,7 @@
     "Robot State": {
       "Collapsed": "0",
       "Pos": "5,20",
-      "Size": "109,134"
+      "Size": "126,152"
     }
   }
 }

--- a/simgui.json
+++ b/simgui.json
@@ -1,7 +1,52 @@
 {
+  "HALProvider": {
+    "Addressable LEDs": {
+      "window": {
+        "visible": true
+      }
+    },
+    "Timing": {
+      "window": {
+        "visible": false
+      }
+    }
+  },
   "NTProvider": {
     "types": {
-      "/FMSInfo": "FMSInfo"
+      "/FMSInfo": "FMSInfo",
+      "/SmartDashboard/Field": "Field2d"
+    },
+    "windows": {
+      "/SmartDashboard/Field": {
+        "bottom": 1476,
+        "height": 8.210550308227539,
+        "left": 150,
+        "right": 2961,
+        "top": 79,
+        "width": 16.541748046875,
+        "window": {
+          "visible": true
+        }
+      }
+    }
+  },
+  "NetworkTables": {
+    "transitory": {
+      "Shuffleboard": {
+        "open": true
+      },
+      "SmartDashboard": {
+        "drivetrain": {
+          "odometry": {
+            "open": true
+          },
+          "open": true
+        },
+        "open": true,
+        "visiontest": {
+          "open": true
+        }
+      }
     }
   },
   "NetworkTables Info": {

--- a/subsystems/drivetrain.py
+++ b/subsystems/drivetrain.py
@@ -123,7 +123,7 @@ class Drivetrain(Subsystem):
                 self.backRight.getPosition(),
             ),
             Pose2d(),
-            (0, 0, 0),  # wheel std devs for Kalman filters
+            (1, 1, 1),  # wheel std devs for Kalman filters
             (0, 0, 0),  # vision std devs for Kalman filters
         )
 


### PR DESCRIPTION
Here we toss the robot pose data into NetworkTables / SmartDashboard where many tools can help visualize it.

We also turn up the standard deviation values for the wheel odometry. While this isn't correct a value of 0 means the vision data was being ignored.